### PR TITLE
bug(mdc-datepicker): make disabled dates appear disabled

### DIFF
--- a/packages/mdc-datepicker/mdc-datepicker.scss
+++ b/packages/mdc-datepicker/mdc-datepicker.scss
@@ -150,6 +150,7 @@
       &--disabled {
         a {
           @include theme.property(color, text-hint-on-background);
+          cursor: not-allowed;
         }
       }
 

--- a/packages/mdc-datepicker/src/mdc-datepicker-dialog/mdc-datepicker-dialog.html
+++ b/packages/mdc-datepicker/src/mdc-datepicker-dialog/mdc-datepicker-dialog.html
@@ -32,12 +32,11 @@
           <div repeat.for="d of days" class="mdc-datepicker-dialog__day
           ${d.date===date ? 'mdc-datepicker-dialog__day--selected' : ''}
           ${d.disabled ? 'mdc-datepicker-dialog__day--disabled' : ''}">
-            <a href="#" mdc-ripple="unbounded.bind: true; disabled.bind: d.disabled" click.trigger="select(d)"
+            <a href="#" mdc-ripple="unbounded.bind: true" click.trigger="select(d)"
                if.bind="d.date && !d.disabled">
               <span>${d.date | date:'d'}</span>
             </a>
-            <a href="#" click.trigger="select(d)"
-               if.bind="d.date && d.disabled">
+            <a if.bind="d.date && d.disabled">
               <span>${d.date | date:'d'}</span>
             </a>
           </div>

--- a/packages/mdc-datepicker/src/mdc-datepicker-dialog/mdc-datepicker-dialog.html
+++ b/packages/mdc-datepicker/src/mdc-datepicker-dialog/mdc-datepicker-dialog.html
@@ -32,7 +32,7 @@
           <div repeat.for="d of days" class="mdc-datepicker-dialog__day
           ${d.date===date ? 'mdc-datepicker-dialog__day--selected' : ''}
           ${d.disabled ? 'mdc-datepicker-dialog__day--disabled' : ''}">
-            <a href="#" mdc-ripple="unbounded.bind: true; disabled.bind: d.disabled" click.trigger="select(d)"
+            <a href="#" mdc-ripple="unbounded.bind: true; disabled.bind: d.disabled" disabled.bind="d.disabled" click.trigger="select(d)"
               if.bind="d.date"><span>${d.date | date:'d'}</span>
             </a>
           </div>

--- a/packages/mdc-datepicker/src/mdc-datepicker-dialog/mdc-datepicker-dialog.html
+++ b/packages/mdc-datepicker/src/mdc-datepicker-dialog/mdc-datepicker-dialog.html
@@ -32,8 +32,13 @@
           <div repeat.for="d of days" class="mdc-datepicker-dialog__day
           ${d.date===date ? 'mdc-datepicker-dialog__day--selected' : ''}
           ${d.disabled ? 'mdc-datepicker-dialog__day--disabled' : ''}">
-            <a href="#" mdc-ripple="unbounded.bind: true; disabled.bind: d.disabled" disabled.bind="d.disabled" click.trigger="select(d)"
-              if.bind="d.date"><span>${d.date | date:'d'}</span>
+            <a href="#" mdc-ripple="unbounded.bind: true; disabled.bind: d.disabled" click.trigger="select(d)"
+               if.bind="d.date && !d.disabled">
+              <span>${d.date | date:'d'}</span>
+            </a>
+            <a href="#" click.trigger="select(d)"
+               if.bind="d.date && d.disabled">
+              <span>${d.date | date:'d'}</span>
             </a>
           </div>
         </div>


### PR DESCRIPTION
Bug:

When dates are disabled in the datepicker they still get the ripple classes added to them. This makes it look like when you hover over them you can actually select them, even though the select event is never triggered.

This change doesn't apply the ripple classes to disabled dates so they appear properly disabled. 
Also added cursor: not-allowed to the sass for disabled dates although not obvious in the screen shots. 

![image](https://user-images.githubusercontent.com/88147556/135934675-469ce3fa-8b11-47a4-8c83-d240b9b730c9.png)

![image](https://user-images.githubusercontent.com/88147556/135934929-35396f58-dca7-438c-96ad-0fde4d9fce78.png)
